### PR TITLE
Add SIGINT handler

### DIFF
--- a/run_servers.sh
+++ b/run_servers.sh
@@ -33,6 +33,14 @@ force_terminate() {
     fi
 }
 
+sigint_handler() {
+    echo "SIGINT caught - forcing termination ..."
+    force_terminate
+    exit 1
+}
+
+trap 'sigint_handler' SIGINT
+
 # Ask user for choice
 echo "Choose a stream source:"
 echo "A: Live segment template without manifest updates"

--- a/scripts/launch_gateway.sh
+++ b/scripts/launch_gateway.sh
@@ -12,6 +12,14 @@ force_terminate() {
     fi
 }
 
+sigint_handler() {
+    echo "SIGINT caught - forcing termination ..."
+    force_terminate
+    exit 1
+}
+
+trap 'sigint_handler' SIGINT
+
 # Run the app.py script in the background and capture its PID
 python3 app.py config.ini mode=gateway sutc=true &
 APP_PID=$!


### PR DESCRIPTION
This PR introduces the ability to gracefully stop both the bash script and the Python app using CTRL-C (SIGINT).